### PR TITLE
use stable JSON stringification (keys sorted)

### DIFF
--- a/airtable-export.js
+++ b/airtable-export.js
@@ -5,6 +5,7 @@ var geojsonhint = require('@mapbox/geojsonhint')
 var deepEqual = require('deep-equal')
 var rewind = require('geojson-rewind')
 var debug = require('debug')('airtable-github-export')
+var stringify = require('json-stable-stringify')
 
 require('dotenv').config()
 
@@ -114,7 +115,7 @@ function ghWrite (filename, data, branches, message, cb) {
       message: message,
       branch: branch
     }
-    gh.writeFile(filename, JSON.stringify(data, null, 2), opts, done)
+    gh.writeFile(filename, stringify(data, { replacer: null, space: 2 }), opts, done)
   })
   function done (err) {
     if (err) return cb(err)

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dotenv": "^4.0.0",
     "geojson-rewind": "^0.2.0",
     "hubfs.js": "^1.0.0",
+    "json-stable-stringify": "^1.0.1",
     "run-parallel": "^1.1.6"
   },
   "devDependencies": {},


### PR DESCRIPTION
When the JSON needs to be written out anew to github, the keys may be written out in a different order resulting in more differences than necessary due to a key/value being moved from one line to another.

Using json-stable-stringify ensures the keys are written out in the same order each time.

Tested in my own code.